### PR TITLE
rejects objects when expecting a string

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -59,7 +59,7 @@ export interface ValidatorFactory<C> {
  */
 export interface ConfigBase<T> {
   /** Parser to convert value into the designated type. */
-  parser: (value: unknown) => T | null | undefined;
+  parser: (value: unknown) => T | null | undefined | object;
   /** Provide a fallback value in case the original value is undefined. */
   default?: T;
 }
@@ -155,6 +155,14 @@ export function createTypeValidatorTest<T, C extends ConfigBase<T>>(
 
     return async (value, field) => {
       const parsedValue = applyConfig(value, finalConfig);
+
+      if (
+        parsedValue !== null &&
+        typeof parsedValue === 'object' &&
+        !(parsedValue instanceof Date)
+      ) {
+        return invalid('Value is an object.', parsedValue, field, null);
+      }
 
       const results = await Promise.all(
         allTests.map(validatorTest => validatorTest(parsedValue, field))

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -2,6 +2,7 @@ import {
   ConfigBase,
   createTypeValidatorTest,
   invalid,
+  isObject,
   valid,
   ValidatorMessage,
   ValidatorTest,
@@ -24,13 +25,11 @@ export interface StringConfig extends ConfigBase<string> {
  * @param value Value to parse
  * @category Parsers
  */
-export function parseString(
-  value: unknown
-): string | null | undefined | object {
+export function parseString(value: unknown): string | null | undefined {
   if (value === null || value === undefined) return value;
   if (typeof value === 'string') return value;
   if (value instanceof Date) return value.toISOString();
-  if (typeof value === 'object') return value;
+  if (isObject(value)) throw new TypeError('Failed to parse value to string.');
   return String(value);
 }
 
@@ -43,7 +42,7 @@ export function parseString(
 export function applyStringConfig(
   value: unknown,
   config: StringConfig
-): string | null | undefined | object {
+): string | null | undefined {
   let parsedValue = config.parser(value);
   if (config.default !== undefined && parsedValue === undefined) {
     parsedValue = config.default;

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -24,10 +24,13 @@ export interface StringConfig extends ConfigBase<string> {
  * @param value Value to parse
  * @category Parsers
  */
-export function parseString(value: unknown): string | null | undefined {
+export function parseString(
+  value: unknown
+): string | null | undefined | object {
   if (value === null || value === undefined) return value;
   if (typeof value === 'string') return value;
   if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'object') return value;
   return String(value);
 }
 
@@ -40,7 +43,7 @@ export function parseString(value: unknown): string | null | undefined {
 export function applyStringConfig(
   value: unknown,
   config: StringConfig
-): string | null | undefined {
+): string | null | undefined | object {
   let parsedValue = config.parser(value);
   if (config.default !== undefined && parsedValue === undefined) {
     parsedValue = config.default;

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -123,4 +123,11 @@ test('string', async () => {
     message: 'Must enter a value.',
     value: null,
   });
+  expect(await validate({ name: 'August' })).toEqual({
+    isValid: false,
+    state: 'invalid',
+    errors: null,
+    message: 'Value is an object.',
+    value: { name: 'August' },
+  });
 });

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -127,7 +127,7 @@ test('string', async () => {
     isValid: false,
     state: 'invalid',
     errors: null,
-    message: 'Value is an object.',
+    message: 'Failed to parse value to string.',
     value: { name: 'August' },
   });
 });


### PR DESCRIPTION
Fixes #1. Passes objects through string parser without coercing to string, and extends shared type validator to reject objects with a generic message.